### PR TITLE
Prevent corrupt Alias after restart of container.

### DIFF
--- a/2.4/docker-entrypoint.sh
+++ b/2.4/docker-entrypoint.sh
@@ -29,7 +29,7 @@ fi
 
 # Configure dav.conf
 if [ "x$LOCATION" != "x" ]; then
-    sed -e "s|Alias /|Alias $LOCATION|" \
+    sed -e "s|Alias .*|Alias $LOCATION /var/lib/dav/data/|" \
         -i "$HTTPD_PREFIX/conf/conf-available/dav.conf"
 fi
 if [ "x$REALM" != "x" ]; then


### PR DESCRIPTION
When the `LOCATION` environment variable is set then a restart of a container will lead to a corrupt Alias configuration. The command `sed -e "s|Alias /|Alias $LOCATION|"` will be executed again and thereby prepend the existing path with the same path.

E.g. `LOCATION=/mydata` 
1. then after the first start the Alias will be configured as:
    `Alias /mydata /var/lib/dav/data/`
2. after a restart the part `Alias /` will be replaced and then the configuration will be:
    `Alias /mydata/mydata /var/lib/dav/data`
3. etc.